### PR TITLE
Add artifactory field parameter to time_based_retention function

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt version

--- a/src/lavatory/utils/artifactory.py
+++ b/src/lavatory/utils/artifactory.py
@@ -217,7 +217,7 @@ class Artifactory:
         artifacts = self.filter(item_type=item_type, depth=depth, fields=fields)
         return artifacts
 
-    def time_based_retention(self, keep_days=None, time_field='created', item_type='file', extra_aql=None):
+    def time_based_retention(self, keep_days=None, time_field='created', item_type='file', extra_aql=None, fields=None):
         """Retains artifacts based on number of days since creation.
 
             extra_aql example: [{"@deployed": {"$match": "dev"}}, {"@deployed": {"$nmatch": "prod"}}]
@@ -229,6 +229,7 @@ class Artifactory:
             time_field (str): The field of time to look at (created, modified, stat.downloaded).
             item_type (str): The item type to search for (file/folder/any).
             extra_aql (list). List of extra AQL terms to apply to search
+            fields (list): List of artifactory fields to return per matching artifact
 
         Return:
             list: List of artifacts matching retention policy
@@ -241,7 +242,7 @@ class Artifactory:
         created_before = before.strftime("%Y-%m-%dT%H:%M:%SZ")
         aql_terms = [{time_field: {"$lt": created_before}}]
         aql_terms.extend(extra_aql)
-        purgeable_artifacts = self.filter(item_type=item_type, depth=None, terms=aql_terms)
+        purgeable_artifacts = self.filter(item_type=item_type, depth=None, terms=aql_terms, fields=fields)
         return purgeable_artifacts
 
     def count_based_retention(self,


### PR DESCRIPTION
Currently, util's/artifactory.py's time_based_retention function returns a list of artifacts to purge,
but it doesn't include the actual time value in the result.

For logging purposes, it'd be great to include said property and others via a fields parameter,
which is what this change is.